### PR TITLE
add esy stuff to ocaml template

### DIFF
--- a/templates/OCaml.gitignore
+++ b/templates/OCaml.gitignore
@@ -27,3 +27,8 @@ setup.log
 
 # Local OPAM switch
 _opam/
+
+# Esy-related generated files
+_esy/
+_build.prev/
+node_modules/


### PR DESCRIPTION
## New or update
### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Hello, [esy](https://esy.sh) is a build system that works (primarily) with OCaml. I added to the ocaml .gitignore stuff that is related to esy.