### PR TITLE
Deduplicate Jupyter and IPython directives out of Python template.

### DIFF
--- a/templates/JupyterNotebooks.gitignore
+++ b/templates/JupyterNotebooks.gitignore
@@ -4,6 +4,9 @@
 .ipynb_checkpoints
 */.ipynb_checkpoints/*
 
+# IPython
+profile_default/
+ipython_config.py
+
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
-#

--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -73,13 +73,6 @@ docs/_build/
 # PyBuilder
 target/
 
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
 # pyenv
 .python-version
 


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

IPython and Jupyter share the same origins.