### PR TITLE
Move all virtualenv related ignore directives out of Python template.

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -96,15 +96,6 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/templates/VirtualEnv.gitignore
+++ b/templates/VirtualEnv.gitignore
@@ -8,5 +8,11 @@
 [Ll]ocal
 [Ss]cripts
 pyvenv.cfg
+.env
 .venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 pip-selfcheck.json


### PR DESCRIPTION
### Update

- [ x] Template - Update existing `.gitignore` template

## Details

Since there is a dedicated ignore file for virtualenv, let's deduplicate the default entries from the Python template.