### PR TITLE
Add Maven Flatten Plugin file

### DIFF
--- a/templates/Maven.gitignore
+++ b/templates/Maven.gitignore
@@ -8,3 +8,4 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
+.flattened-pom.xml


### PR DESCRIPTION
First of all, thanks for this awasome project, which has saved me countless `Update .gitignore` commits :+1: 

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The [Maven Flatten Plugin](https://www.mojohaus.org/flatten-maven-plugin/) generates a '.flattened-pom.xml' which should usually not be committed to git. The plugin is needed e.g. for continuous integration with multi-module projects.