### PR TITLE
add migrations folder in django template

### DIFF
--- a/templates/Django.gitignore
+++ b/templates/Django.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 local_settings.py
 db.sqlite3
 media
+migrations/
+!migrations/__init__.py
 
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

I referred to the link below.
"https://stackoverflow.com/questions/28035119/should-i-be-adding-the-django-migration-files-in-the-gitignore-file"
Therefore, 'migrations' folder has been included in '.gitignore'.