### PR TITLE
Create Android+reports.patch

### DIFF
--- a/templates/Android+reports.patch
+++ b/templates/Android+reports.patch
@@ -1,0 +1,2 @@
+# Reports
+reports/


### PR DESCRIPTION
### New
- Patch - Extends [Android.gitignore](https://github.com/toptal/gitignore/blob/master/templates/Android.gitignore) to ignore reports directory on root level project folder, i think it contains lint reports.

NB : i don't know about, weather the lint tool creates reports folder in subprojects or not, but using a rule like `*/reports` will cause source folders with a name reports ignorance.

NB : This ignore rule is optional, use only if you need it.