### PR TITLE
Update Unity.gitignore

### DIFF
--- a/templates/Unity.gitignore
+++ b/templates/Unity.gitignore
@@ -57,6 +57,7 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+*.symbols.zip
 
 # Crashlytics generated file
 crashlytics-build.properties


### PR DESCRIPTION
Added an ignore entry for the IL2CPP symbols files.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Just added a new line for the symbols zip file that is generated during IL2CPP builds. These files are really heavy (1-2GB+) and shouldn't be committed. 