### PR TITLE
Gitignore for Zshell

### DIFF
--- a/templates/Zsh.gitignore
+++ b/templates/Zsh.gitignore
@@ -1,0 +1,28 @@
+# Zsh compiled script + zrecompile backup
+*.zwc
+*.zwc.old
+
+# Zsh completion-optimization dumpfile
+*zcompdump*
+
+# Zsh zcalc history
+.zcalc_history
+
+# A popular plugin manager's files
+._zplugin
+.zplugin_lstupd
+
+# zdharma/zshelldoc tool's files
+zsdoc/data
+
+# robbyrussell/oh-my-zsh/plugins/per-directory-history plugin's files
+# (when set-up to store the history in the local directory)
+.directory_history
+
+# MichaelAquilina/zsh-autoswitch-virtualenv plugin's files
+# (for Zsh plugins using Python)
+.venv
+
+# Zunit tests' output
+/tests/_output/*
+!/tests/_output/.gitkeep


### PR DESCRIPTION
### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

## Details

The docs about the entries:


- [zsh.sf.net/Files](http://zsh.sourceforge.net/Doc/Release/Files.html#Files-1) – search for "zwc"
- [zsh.sf.net/use of compinit](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Use-of-compinit) – search for "zcompdump". The file can have a hostname appended and also the user may customize it (a bit, presumably) hence the wildcards in the template
- [zplugin](https://github.com/zdharma/zplugin#updating-zplugin-and-plugins) – search for "._zplugin". The files will appear when developing a Zsh plugin with use of Zplugin, hence their presence in the template.
- [zshelldoc](https://github.com/zdharma/zshelldoc) – search for `data`. When developing a Zsh-plugin and documenting the code with Zshelldoc, this directory will pop-up in `git status` without any need for commit,
- [per-directory-history](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/per-directory-history) – search for ".directory_history". The plugin can be configured to store the history in the local directory instead of `$HOME`,
- [zsh-autoswitch-virtualenv](https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv) – search for ".venv".
- [zunit](https://zunit.xyz/docs/usage/reporting/) – the tests can produce results in the `_output` directory.