### PR TITLE
Android Studio: Ignore .cxx directories in v3.5

### DIFF
--- a/templates/Android.patch
+++ b/templates/Android.patch
@@ -1,2 +1,6 @@
 gen-external-apklibs
 output.json
+
+# Replacement of .externalNativeBuild directories introduced
+# with Android Studio 3.5.
+.cxx/


### PR DESCRIPTION
Android Studio 3.5 introduced `.cxx` directories containing CMake configuration
directories, similar to `.externalNativeBuild`.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

I am observing that Android Studio is creating these directories when you have C++ & CMake support in your project. It seems to be similar to or a replacement of the .externalNativeBuild directories that were there before.

I contacted the developers on the Android Studio team. They confirmed this is an official change. It's the renamed version of the former .externalNativeBuild directory. However it isn't in the release notes.

My [original upstream PR](https://github.com/github/gitignore/pull/3155) that was ignored for over a month, so I'm offering the patch here instead.