### PR TITLE
Added e2studio.gitignore template.

### DIFF
--- a/templates/e2studio.gitignore
+++ b/templates/e2studio.gitignore
@@ -1,0 +1,10 @@
+# Modified gitignore for Renesas E2Studio (Built on eclipse): maintain all data needed by eclipse to setting up a workspace.
+
+.history
+*.tmp
+*.obj
+*.log
+history.index
+
+# E2 Studio Specific
+HardwareDebug/src


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

e2studio is a IDE for Renesas Microcontrollers and it's built on eclipse. However, using the standard eclipse.gitignore may cause problems when cloning a repository, losing workspace specific settings (commonly used in this kind of environment, e.g in multiple projects in a same workspace). So, I have created this e2studio.ignore file in order to solve my problems with porting a workspace and ignoring unuseful files.

Link for more information about e2studio: https://www.renesas.com/in/en/products/software-tools/tools/ide/e2studio.html