### PR TITLE
add clj-kondo cache folder to clojure template

### DIFF
--- a/templates/Clojure.gitignore
+++ b/templates/Clojure.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.clj-kondo/.cache/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

clj-kondo is a linter for clojure https://github.com/borkdude/clj-kondo
I noticed that its cache folder is not currently in any template. Please let me know if it's better located in a different file.