### PR TITLE
Remove *.meta ignore due Unity projects must to keep tracking of this file

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -68,7 +68,6 @@ StyleCopReport.xml
 *_p.c
 *_h.h
 *.ilk
-*.meta
 *.obj
 *.iobj
 *.pch


### PR DESCRIPTION
**Remove *.meta ignore due Unity projects must to keep tracking of this file**

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The files *.meta are very important to Unity projects. Once VisualStudio is most used to code for this platform, ignore this file will lead to problems sharing the Unity project over Git remote repository.