### PR TITLE
Remove bin, local, include, scripts in VirtualEnv.gitignore

### DIFF
--- a/templates/VirtualEnv.gitignore
+++ b/templates/VirtualEnv.gitignore
@@ -1,12 +1,6 @@
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
 .Python
-[Bb]in
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-[Ll]ocal
-[Ss]cripts
 pyvenv.cfg
 .env
 .venv


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [*] Template - Update existing `.gitignore` template

## Details

A lot of sub directory or sub module in python project named 'bin' (for executable scripts which will install to /usr/bin/), local (some module of this python project.), include (python, C mixed project for external API definition), scripts (for test, or maintain script).

They all need to be tracked in git repo.

venv, .venv is quite enough, if there is virtualenv which need to be name as other name. It would be better for user to add them manually. 