### PR TITLE
Update Eagle.gitignore to fit new Eagle default cam-job file *.gbr extension

### DIFF
--- a/templates/Eagle.gitignore
+++ b/templates/Eagle.gitignore
@@ -36,6 +36,7 @@ eagle.epf
 *.pls
 *.ger
 *.xln
+*.gbr
 
 *.drd
 *.drd.*


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

To fit new Eagle default cam-job file extension