### PR TITLE
Error in foldername bower_componets

### DIFF
--- a/templates/Vue.gitignore
+++ b/templates/Vue.gitignore
@@ -5,7 +5,7 @@ logs
 **/*.back.*
 
 node_modules
-bower_componets
+bower_components
 
 *.sublime*
 

--- a/templates/react.gitignore
+++ b/templates/react.gitignore
@@ -5,7 +5,7 @@ logs
 **/*.back.*
 
 node_modules
-bower_componets
+bower_components
 
 *.sublime*
 


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Both Vue.gitignore and react.gitignore contain the same error:
**bower_componets** instead of **bower_components**