### PR TITLE
KiCad: Ignore schematic backups

### DIFF
--- a/templates/KiCad.gitignore
+++ b/templates/KiCad.gitignore
@@ -5,6 +5,7 @@
 *.000
 *.bak
 *.bck
+*.sch-bak
 *.kicad_pcb-bak
 *~
 _autosave-*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Current KiCad template only ignores temporary files generated for the project (\*.bak) or the board (\*.kicad_pcb-bak). This PR adds those for schematics (\*.sch-bak)