### PR TITLE
Ignore Rails 6 master.key used on the new credentials mechanism

### DIFF
--- a/templates/Rails.gitignore
+++ b/templates/Rails.gitignore
@@ -64,3 +64,6 @@ yarn-debug.log*
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep
+
+# Ignore master key for decrypting credentials and more.
+/config/master.key


### PR DESCRIPTION
### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The new "secrets" mechanism of rails, that is the default on the lastest versions, "credentials" generates a `master.key` that should not be committed into versioning. `rails new` already adds it into the generated `.gitignore` file, but [gitignore.io](gitignore.io) doesn't have it yet.

More info on this PR: https://github.com/rails/rails/pull/30067
