### PR TITLE
Allow files within .vagrant to be included

### DIFF
--- a/templates/Vagrant.gitignore
+++ b/templates/Vagrant.gitignore
@@ -1,5 +1,5 @@
 # General
-.vagrant/
+.vagrant/*
 
 # Log files (if you are creating logs in debug mode, uncomment this)
 # *.log


### PR DESCRIPTION
Currently the rule does not allow files within vagrant to be included using "!.vagrant/filename", this change allows that and should not break existing functionality.

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The current vagrant rule ignore the .vagrant directory entirely, meaning that files within it cannot be excluded from the rune using "!", this change allows that to happen.

This allows putting vagrant-specific scripts and files within the .vagrant folder.