### PR TITLE
Fix rule for AxoCover to exclude folder structure.

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -134,7 +134,7 @@ _TeamCity*
 *.dotCover
 
 # AxoCover is a Code Coverage Tool
-.axoCover/*
+.axoCover/
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool


### PR DESCRIPTION
# Pull Request

### Update

- [ X ] Template - Update existing `.gitignore` template

## Details

The rule excluded files in the folder, but not child folder structure. Current version of AxoCover stores files in a structure like this: .axoCover\runs\run_x_y_z\