### PR TITLE
Ignore Visual Studio Code workspace settings

### DIFF
--- a/templates/Unity.gitignore
+++ b/templates/Unity.gitignore
@@ -22,6 +22,10 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code workspace settings
+.vscode/*
+*.code-workspace
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

From my point of view, it's more convenient to ignore vscode workspace settings by default.
And this variant is compatible with vscode .gitignore if you later decide to commit your settings and debug tasks.