### PR TITLE
Jetbrains: ignore private environment settings

### DIFF
--- a/templates/JetBrains.gitignore
+++ b/templates/JetBrains.gitignore
@@ -66,6 +66,8 @@ fabric.properties
 
 # Editor-based Rest Client
 .idea/httpRequests
+http-client.private.env.json
+rest-client.private.env.json
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The built-in HTTP client supports different environment via configuration files with the names http-client.env.json or rest-client.env.json. The environment configurations might include private data like credentials which should not be tracked by version control systems. Private data can be stored in the files http-client.private.env.json or rest-client.private.env.json and thus these files have to be ignored by Git.