### PR TITLE
Replace dead link to virtualenv guide

### DIFF
--- a/templates/VirtualEnv.gitignore
+++ b/templates/VirtualEnv.gitignore
@@ -1,5 +1,5 @@
 # Virtualenv
-# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+# https://realpython.com/python-virtual-environments-a-primer/
 .Python
 [Bb]in
 [Ii]nclude


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The URL for the old virtualenv guide is dead as of 2020 Jan 14. According to archive.org, it appears that the original article was taken down sometime around November 2018. The article itself was written in 2009 and was based on Python 2.5, so it was long overdue for a replacement.

I suggested a tutorial at RealPython (no affiliation, personal preference), but really any of the top search results for "virtualenv guide" would do. Alternatives:

* https://docs.python.org/3/tutorial/venv.html (from official docs, but a little sparse)
* https://towardsdatascience.com/virtual-environments-104c62d48c54
* https://python-guide-kr.readthedocs.io/ko/latest/dev/virtualenvs.html