### PR TITLE
in Metals, ignore the project/metals.sbt file

### DIFF
--- a/templates/Metals.gitignore
+++ b/templates/Metals.gitignore
@@ -1,1 +1,2 @@
 .metals/
+project/metals.sbt


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The latest version of the metals project started creating this file and
it also recommends ignoring it.
* https://scalameta.org/metals/docs/editors/vim.html#gitignore-projectmetalssbt-metals-and-bloop