### PR TITLE
Add template for nohup (ignoring `nohup.out`)

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -142,6 +142,7 @@ copy:
   - templates/Nim.gitignore: Nim.gitignore
   - templates/Ninja.gitignore: Ninja.gitignore
   - templates/Node.gitignore: Node.gitignore
+  - templates/Nohup.gitignore: Nohup.gitignore
   - templates/NotepadPP.gitignore: NotepadPP.gitignore
   - templates/Nuxt.gitignore: Nuxt.gitignore
   - templates/NWjs.gitignore: NWjs.gitignore

--- a/templates/Nohup.gitignore
+++ b/templates/Nohup.gitignore
@@ -1,0 +1,1 @@
+nohup.out


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

Pretty simple, really - ignore `nohup.out`. 

I use nohup sometimes when I'm developing code in a directory and want to run a service in that directory but without all the log output in the terminal window. E.g., coding for a data science project and running `jupyter notebook` in the same folder. I use `nohup` for this to avoid jupyter's log output.. but it makes a ugly `nohup.out` file. So I `gitignore` it. 

I was expecting to see this as an option on gitignore.io - perhaps it's sensible to add? 