### PR TITLE
Ignored Fastlane.swift runner binary

### DIFF
--- a/templates/fastlane.gitignore
+++ b/templates/fastlane.gitignore
@@ -17,3 +17,6 @@ fastlane/screenshots/screenshots.html
 
 # scan temporary files
 fastlane/test_output
+
+# Fastlane.swift runner binary
+fastlane/FastlaneRunner


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

- Ignored Fastlane.swift runner binary, as its Xcode project and source code is available on the repo which Fastlane.swift is installed on, and it is being built by Fastlane when needed, so tracking this binary is unnecessary overhead.

- https://docs.fastlane.tools/getting-started/ios/fastlane-swift/