### PR TITLE
Add LIPIcs / OASIcs TOC entries

### DIFF
--- a/templates/TeX.patch
+++ b/templates/TeX.patch
@@ -1,2 +1,5 @@
+# LIPIcs / OASIcs
+*.vtc
+
 # glossaries
 *.glstex


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The [LIPIcs and OASIcs document classes](https://submission.dagstuhl.de/documentation/authors) are used in document preparation for contributions to larger proceedings. They emit some metadata in a `vtc` file that can then be used by the volume editors to create a TOC. Since this is a generated file and I can find no other use of this extension in LaTeX writing, it should be ignored.