### PR TITLE
QtCreator: ignore files with flags of Clang code model

### DIFF
--- a/templates/QtCreator.gitignore
+++ b/templates/QtCreator.gitignore
@@ -24,3 +24,7 @@
 
 # Qt Creator backups
 *.autosave
+
+# Flags for Clang Code Model
+*.cxxflags
+*.cflags


### PR DESCRIPTION
# Pull Request

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The **.cxxflags** and **.cflags** files contain command line flags for the Clang code model on a single line. QtCreator like IDE use this files in process work.

more details: [https://doc.qt.io/qtcreator/creator-project-generic.html](https://doc.qt.io/qtcreator/creator-project-generic.html)