### PR TITLE
Exclude additional kitchen configurations

### DIFF
--- a/templates/ChefCookbook.gitignore
+++ b/templates/ChefCookbook.gitignore
@@ -7,3 +7,6 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.kitchen.*.local.yml
+kitchen.local.yml
+kitchen.*.local.yml


### PR DESCRIPTION
Adds updated best practice of not using dotfile and excludes all local files

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Excludes any local kitchen yaml file was well as the current best practice of not using a dotfile.