### PR TITLE
Update gitignore for TwinCAT

### DIFF
--- a/templates/TwinCAT.gitignore
+++ b/templates/TwinCAT.gitignore
@@ -3,6 +3,8 @@
 # TwinCAT 3.1
 
 *.tpy
+# ignoring the TMC file is only useful for plain PLC programming
+# as soon as shared data types (via tmc), C++ or in general TcCom-Module are used, the TMC file has to be part of the repository
 *.tmc
 *.tsproj.bak
 *.plcproj.bak


### PR DESCRIPTION
as wirtten in the commend, gnoring the TMC file is only useful for plain PLC programming, as soon as shared data types (via tmc) or in general TcCom-Module are used, the TMC file has to be part of the repository

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

*replace this section with links and/or info about the proposed request*