### PR TITLE
added ignore for .ionide folder

### DIFF
--- a/templates/fsharp.gitignore
+++ b/templates/fsharp.gitignore
@@ -8,3 +8,4 @@ bin
 /build/
 *.exe
 !.paket/paket.bootstrapper.exe
+.ionide/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Updated fsharp template to ignore the .ionide folder that is added when writing F# in vscode + ionide extension. This could fall under the visualstudiocode template, however it's related to the smaller number of people using vscode & F#