### PR TITLE
Meson: create template to ignore meson subprojects

### DIFF
--- a/templates/Meson.gitignore
+++ b/templates/Meson.gitignore
@@ -1,0 +1,3 @@
+# subproject directories
+/subprojects/*
+!/subprojects/*.wrap


### PR DESCRIPTION
Meson is a build system (mesonbuild.com).

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [X ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

Create a template for [Meson](mesonbuild.com) and start with the subproject source code directories.  Subprojects are represented by a project.wrap file, which needs to be checked in
and then meson will populate a project-version subdirectory with the subproject's source code.