### PR TITLE
Include Rider as being covered

### DIFF
--- a/templates/JetBrains.gitignore
+++ b/templates/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

### Details

According to [this somewhat offical JetBrains.gitignore](https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore), Rider is also covered.