### PR TITLE
Fixed ignore everything except the "wp-content"

### DIFF
--- a/templates/WordPress.gitignore
+++ b/templates/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### Update

- [ x] Template - Update existing `.gitignore` template

## Details

I don't know what the situation looks like on Unix systems, but in Git for Windows we have to add `/*` at the beginning of the file to properly ignore