### PR TITLE
Adds alternative python documentation path `doc`

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+doc/_build/
 
 # PyBuilder
 target/


### PR DESCRIPTION


# Pull Request

Adds `doc/_build` as additional ignore path next to `docs/_build`.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

While Kenneth Reitz [recommends](https://kenreitz.org/essays/repository-structure-and-python) `docs`, many projects use `doc` (without `s`) as subdirectory for the documentation. I've seen both `docs` and `doc` used frequently in various python projects (e.g. numpy uses `doc`), so I think it makes sense to have both variants.
