### PR TITLE
Add lib/generated_plugin_registrant.dart

### DIFF
--- a/templates/Flutter.gitignore
+++ b/templates/Flutter.gitignore
@@ -7,6 +7,7 @@
 .pub-cache/
 .pub/
 build/
+lib/generated_plugin_registrant.dart
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

lib/generated_plugin_registrant.dart is a file generated by flutter web automatically
This should be added to .gitignore
It has already been part of .gitignore generated by 'flutter create' command since https://github.com/flutter/flutter/pull/39781