### PR TITLE
Fix build error (add newline to end of AL.gitignore)

### DIFF
--- a/templates/AL.gitignore
+++ b/templates/AL.gitignore
@@ -7,3 +7,4 @@
 *.app
 #Translation Base-file
 *.g.xlf
+


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

all builds have been failing recently for new PRs

build failures are due to a lint error caused by `templates/AL.gitignore`:

```
  Lint templates for white space then run moban0s
##[error]Process completed with exit code 1.
Run .github/scripts/check-whitespace.sh
  .github/scripts/check-whitespace.sh
  moban
  git diff --exit-code
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.7.6/x64
File 'templates/AL.gitignore' is missing EOF line
##[error]Process completed with exit code 1.
 Rebuild gitignore.io
```

This PR adds a new line to the file, hopefully fixing the build problem
