### PR TITLE
Add hugo_stats.json for Hugo

### DIFF
--- a/templates/Hugo.gitignore
+++ b/templates/Hugo.gitignore
@@ -1,6 +1,7 @@
 # Generated files by hugo
 /public/
 /resources/_gen/
+hugo_stats.json
 
 # Executable may be added to repository
 hugo.exe


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Introduced in v0.69.0, Hugo could write a hugo_stats.json file. This is
related to the PostProcess pipe, which is described here:

https://gohugo.io/hugo-pipes/postprocess/
