### PR TITLE
now rename to vercel

### DIFF
--- a/templates/now.gitignore
+++ b/templates/now.gitignore
@@ -1,1 +1,2 @@
 .now
+.vercel


### PR DESCRIPTION
now rename to vercel

### Update

- [x] Template - Update existing `.gitignore` template

## Details

https://vercel.com/blog/zeit-is-now-vercel