### PR TITLE
Ignore debug log pytest artifact.

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+pytestdebug.log
 
 # Translations
 *.mo


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Python's popular `pytest` framework stores its internal debug log in `pytestdebug.log` file by default. See: https://github.com/pytest-dev/pytest/blob/88214310af73c0a4400707b1702832216e09b32d/src/_pytest/helpconfig.py#L76