### PR TITLE
[Flutter] Ignoring android/key.properties

### DIFF
--- a/templates/Flutter.gitignore
+++ b/templates/Flutter.gitignore
@@ -14,6 +14,7 @@ build/
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat
+**/android/key.properties
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
 


### PR DESCRIPTION
Based on advice from https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app

# Pull Request

## Update

- [X] Template - Update existing `.gitignore` template

## Details
 * https://github.com/toptal/gitignore.io/issues/493
