### PR TITLE
Add .env*.local to Node.gitignore

### DIFF
--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -71,6 +71,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -71,7 +71,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
-.env.local
+.env*.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

According to the Next.js docs (https://nextjs.org/docs/basic-features/environment-variables#default-environment-variables):

> `.env`, `.env.development`, and `.env.production` files should be included in your repository as they define defaults. **`.env*.local` should be added to .gitignore**, as those files are intended to be ignored. `.env.local` is where secrets can be stored.

Until the Next.js team decides this was a bad idea and switches to using a regular old `.env` file, it seems prudent to add `.env*.local` to the gitignore so that Next.js project secrets aren't accidentally exposed.