### PR TITLE
Add pythonenv wildcard

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -111,6 +111,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pythonenv*
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
- [X] Patch - Template extending functionality of existing template
- [X] Template - Update existing `.gitignore` template

## Details

Github Codespaces automatically create a pythonenv folder. For example: `pythonenv3.8/` which containts a virtual environment. This should not be commited by default.