### PR TITLE
Add .bsp folder to ignore

### DIFF
--- a/templates/SBT.gitignore
+++ b/templates/SBT.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

With release of SBT 1.4.0 new .bsp folder created by sbt. it contains configuration for machine-readable instruction for build server protocol usages.
More details is here https://github.com/sbt/sbt/releases/tag/v1.4.0