### PR TITLE
fix: Ignore metals.sbt anywhere inside project

### DIFF
--- a/templates/Metals.gitignore
+++ b/templates/Metals.gitignore
@@ -1,3 +1,3 @@
 .metals/
 .bloop/
-project/metals.sbt
+project/**/metals.sbt


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

fix: According to the docs https://scalameta.org/metals/docs/editors/vscode.html#files-and-directories-to-include-in-your-gitignore `metals.sbt` should be ignored anywhere inside `project` directory.