### PR TITLE
Update Terraform .gitignore

### DIFF
--- a/templates/Terraform.gitignore
+++ b/templates/Terraform.gitignore
@@ -18,8 +18,12 @@ crash.log
 # are not checked in
 override.tf
 override.tf.json
+override.auto.tfvars
+override.auto.tfvars.json
 *_override.tf
 *_override.tf.json
+*_override.auto.tfvars
+*_override.auto.tfvars.json
 
 # Include override files you do wish to add to version control using negated pattern
 #


### PR DESCRIPTION
## Update

- [x] Template - Update existing `.gitignore` template

## Details

It's a good practice to ignore `*_override.*.tfvars` files, which are usually used for storing secrets

References:
- https://www.terraform.io/docs/configuration/override.html
- https://www.terraform.io/docs/configuration/variables.html
