### PR TITLE
Added exclusion for Test Coverage results directory.

### DIFF
--- a/templates/Flutter.gitignore
+++ b/templates/Flutter.gitignore
@@ -7,6 +7,7 @@
 .pub-cache/
 .pub/
 build/
+coverage/
 lib/generated_plugin_registrant.dart
 
 # Android related


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Exclude the `coverage` directory because it contains _test coverage_ results, which are similar to _build results_. Test coverage results are generated from the command `flutter test --coverage`.