### PR TITLE
Added note about pubspec.lock because it should be excluded for library packages.

### DIFF
--- a/templates/Flutter.gitignore
+++ b/templates/Flutter.gitignore
@@ -8,6 +8,10 @@
 .pub/
 build/
 lib/generated_plugin_registrant.dart
+# For library packages, don’t commit the pubspec.lock file.
+# Regenerating the pubspec.lock file lets you test your package against the latest compatible versions of its dependencies.
+# See https://dart.dev/guides/libraries/private-files#pubspeclock
+#pubspec.lock
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The [`pubspec.lock`](https://dart.dev/guides/libraries/private-files#pubspeclock) file should be ignored for a _library package_ because regenerating it lets you test your package against the latest compatible versions of its dependencies.

Note that the default is to include it (not ignore it), which is appropriate for _Flutter Applications_.

The developer will need to uncomment out this `pubspec.lock` line for a _Flutter Library_.