### PR TITLE
Ignore .catkin_tools folder

### DIFF
--- a/templates/ROS.gitignore
+++ b/templates/ROS.gitignore
@@ -1,3 +1,4 @@
+.catkin_tools/
 devel/
 logs/
 build/


### PR DESCRIPTION
The `.catkin_tools` folder contains local configurations, e.g. fixed paths to the devel space.

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The `.catkin_folder` folder contains local configurations, e.g. fixed paths to the devel space.
It also mirrors the `package.xml` from each package creating unnecessary files.

I am open to discussions on whether single files/folder shall be excluded from the ignore, thus committed to the vcs.