### PR TITLE
NCrunch template excludes shared settings files

### DIFF
--- a/templates/NCrunch.gitignore
+++ b/templates/NCrunch.gitignore
@@ -2,5 +2,4 @@
 *.ncrunch*
 _NCrunch_*
 *.crunch.xml
-*.ncrunchsolution*
 nCrunchTemp_*

--- a/templates/NCrunch.gitignore
+++ b/templates/NCrunch.gitignore
@@ -1,5 +1,5 @@
 # NCrunch
-*.ncrunch*
+*.ncrunch*.user
 _NCrunch_*
 *.crunch.xml
 nCrunchTemp_*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Currently the NCrunch template includes `*.ncrunch*` and `*.ncrunchsolution*`, which, apart from being redundant, also excludes shared settings files `*.ncrunchsolution` and `*.ncrunchproject`. 

I'm guessing NCrunch got updated at some point and changed there file layout, because they now use the standard of suffixen user specific files with `.user`.

I've removed the redundant line and change the other to not exclude files containing shared settings. In my opinion this better reflects the intention of the files generated by NCrunch.