### PR TITLE
Fix for leading slash on Windows

### DIFF
--- a/templates/DocFx.gitignore
+++ b/templates/DocFx.gitignore
@@ -1,2 +1,2 @@
 .cache
-/**/_site/
+**/_site/

--- a/templates/DotnetCore.gitignore
+++ b/templates/DotnetCore.gitignore
@@ -3,5 +3,5 @@ bin/
 obj/
 
 # Common node modules locations
-/node_modules
-/wwwroot/node_modules
+node_modules
+wwwroot/node_modules

--- a/templates/fsharp.gitignore
+++ b/templates/fsharp.gitignore
@@ -5,7 +5,7 @@ Debug
 *.user
 obj
 bin
-/build/
+build/
 *.exe
 !.paket/paket.bootstrapper.exe
 .ionide/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

This pull request addresses an issue with some of the templates on Windows. When a gitignore line on Windows begins with a forward slash (`/`), it gets treated as if it's referring to the root of the drive (e.g. `C:\`) instead of the root of the repo. I fixed the templates for the languages I am familiar with (DocFx, fsharp, and DotnetCore), but this pattern occurs another 1442 times in this repository, namely 705 times in the Joomla template.