### PR TITLE
feat - Added ignore rule for ltximg directory

### DIFF
--- a/templates/Emacs.gitignore
+++ b/templates/Emacs.gitignore
@@ -11,6 +11,7 @@ tramp
 # Org-mode
 .org-id-locations
 *_archive
+ltximg/**
 
 # flymake-mode
 *_flymake.*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Added ignore rule under Org mode for ltximg directory. This directory contains temporary images created when using `org-latex-preview` command.
