### PR TITLE
Remove obsolete Ruby.patch

### DIFF
--- a/templates/Ruby.patch
+++ b/templates/Ruby.patch
@@ -1,2 +1,0 @@
-# Used by RuboCop. Remote config files pulled in from inherit_from directive.
-# .rubocop-https?--*


### PR DESCRIPTION
File content already included in Ruby.gitignore

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

This change fixes duplication caused by same lines being present in both `Ruby.gitignore` and `Ruby.patch` files.

https://www.toptal.com/developers/gitignore/api/ruby

![chrome_sKcT9SyPkG](https://user-images.githubusercontent.com/7945905/104471908-10e00580-55c4-11eb-972b-05fb7499a79d.png)
