### PR TITLE
Change Travis-CI badge from .org to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <br>
 <p align="center">
     <a href="https://github.com/toptal/gitignore/tree/master/templates"><img src="https://img.shields.io/badge/Templates-500%2B-FF5722.svg?longCache=true&style=flat-square" alt="template count"></a>
-    <a href="https://travis-ci.org/toptal/gitignore"><img src="https://img.shields.io/travis/toptal/gitignore/master?longCache=true&style=flat-square" alt="build status"></a>
+    <a href="https://travis-ci.com/toptal/gitignore"><img src="https://img.shields.io/travis/toptal/gitignore/master?longCache=true&style=flat-square" alt="build status"></a>
     <a href="https://github.com/toptal/gitignore/blob/master/LICENSE.md"><img src="https://img.shields.io/github/license/toptal/gitignore.svg?longCache=true&style=flat-square" alt="license"></a>
 </p>
 


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

Travis-CI is migrating their domain from .org to .com, this update fixes the URL in the `README.md`