### PR TITLE
Re-add Maven Flatten Plugin file

### DIFF
--- a/templates/Maven.gitignore
+++ b/templates/Maven.gitignore
@@ -9,3 +9,4 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+.flattened-pom.xml


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The [Maven Flatten Plugin](https://www.mojohaus.org/flatten-maven-plugin/) generates a '.flattened-pom.xml' which should usually not be committed to git. The plugin is needed e.g. for continuous integration with multi-module projects.

This had already been fixed in #221, but the change was lost again.
