### PR TITLE
Add custom glossary temporary files

### DIFF
--- a/templates/TeX.gitignore
+++ b/templates/TeX.gitignore
@@ -108,6 +108,9 @@ acs-*.bib
 *.glg
 *.glo
 *.gls
+*.*-glg
+*.*-glo
+*.*-gls
 *.glsdefs
 *.lzo
 *.lzs


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

When defining a custom glossary via the `\newglossary*{<label>}{<title>}` command, the corresponding temporary files will have the following extensions:
- `*.<label>-glg`
- `*.<label>-glo`
- `*.<label>-gls`.
 
See p. 174 in the [CTAN documentation](https://ctan.org/pkg/glossaries) "User Manual for glossaries.sty v4.46", Nicola L.C., 2020-03-19.