### PR TITLE
Update Python.gitignore

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -14,8 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Ignoring `lib/` often unexpectedly ignores real code in directories e.g. `src/lib/`.

`python setup.py build` produces `build/lib` directory which I think is what these lines actually want to ignore.  It is already in the ignored `build/` directly however.  So deleting `lib/` and `lib64/` may be a good choice.




