### PR TITLE
Correct VisualStudio coverage pattern.

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -142,7 +142,8 @@ _TeamCity*
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool
-coverage*[.json, .xml, .info]
+coverage*.[ji][sn][of][no]
+coverage*.xml
 
 # Visual Studio code coverage results
 *.coverage


### PR DESCRIPTION
Fix incorrect usage of the "[]" pattern format.

From Git documentation:
  "[]" matches one character in a selected range.

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The previous usage of the range pattern ("[]") did not work as likely intended.  From the [Git documentation](
https://git-scm.com/docs/gitignore/#_pattern_format)

> The range notation, e.g. [a-zA-Z], can be used to match one of the characters in a range.

Assumption was that the following rules were being condensed:
```gitignore
coverage*.json
coverage*.xml
coverage*.info
```

So:
```gitignore
coverage*[.json, .xml, .info]
```
acts as:
```gitignore
coverage*[.json, xmlif]
```
with duplicates removed, where only one character of the range pattern (`[]`) characters will be matched.  The rest of the characters will be matched by the `*`.

This results in unintended matches (e.g. `coveragetype.sql`).  The characters `type.sq` would be matched with `*` and the `l` would be matched by either form, `[.json, .xml, .info]` or `[.json, xmlif]`.

