### PR TITLE
Add .env as an ignored file for Flask

### DIFF
--- a/templates/Flask.gitignore
+++ b/templates/Flask.gitignore
@@ -1,3 +1,4 @@
 instance/*
 !instance/.gitignore
 .webassets-cache
+.env


### PR DESCRIPTION
Flask uses .flaskenv to hold secrets that can be committed, while .env is intended for anything that shouldn't (like database connection strings, for example)

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Flask reccomends using `.env` to hold variables that shouldn't be committed to git, while `.flaskenv` is for variables that are fine in git. So, we should ignore `.env`.