### PR TITLE
Comment out lines for Accio dependency management

### DIFF
--- a/templates/Swift.gitignore
+++ b/templates/Swift.gitignore
@@ -66,9 +66,9 @@ playground.xcworkspace
 
 Carthage/Build/
 
-# Accio dependency management
-Dependencies/
-.accio/
+# Add this lines if you are using Accio dependency management (Deprecated since Xcode 12)
+# Dependencies/
+# .accio/
 
 # fastlane
 #


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Lines for Accio dependency management ignores all folders with name `Dependencies`. Which I believe is not expected in most cases.
I am not familiar with Accio and don't know if only root  `Dependencies` folder should be ignored so I decided to turn off Accio lines.