### PR TITLE
Update WordPress.gitignore, disables its github/gitignore sync

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -228,7 +228,6 @@ targets:
   - templates/Waf.gitignore: Waf.gitignore
   - templates/WebMethods.gitignore: WebMethods.gitignore
   - templates/Windows.gitignore: Windows.gitignore
-  - templates/WordPress.gitignore: WordPress.gitignore
   - templates/Xcode.gitignore: Xcode.gitignore
   - templates/Xilinx.gitignore: Xilinx.gitignore
   - templates/XilinxISE.gitignore: XilinxISE.gitignore

--- a/templates/WordPress.gitignore
+++ b/templates/WordPress.gitignore
@@ -1,23 +1,45 @@
-# ignore everything in the root except the "wp-content" directory.
-!wp-content/
+# Core
+#
+# Note: if you want to stage/commit WP core files
+# you can delete this whole section/until Configuration.
+/wp-admin/
+/wp-content/index.php
+/wp-content/languages
+/wp-content/plugins/index.php
+/wp-content/themes/index.php
+/wp-includes/
+/index.php
+/license.txt
+/readme.html
+/wp-*.php
+/xmlrpc.php
 
-# ignore everything in the "wp-content" directory, except:
-# "mu-plugins", "plugins", "themes" directory
-wp-content/*
-!wp-content/mu-plugins/
-!wp-content/plugins/
-!wp-content/themes/
+# Configuration
+wp-config.php
 
-# ignore these plugins
-wp-content/plugins/hello.php
+# Example themes
+/wp-content/themes/twenty*/
 
-# ignore specific themes
-wp-content/themes/twenty*/
+# Example plugin
+/wp-content/plugins/hello.php
 
-# ignore node dependency directories
-node_modules/
+# Uploads
+/wp-content/uploads/
 
-# ignore log files and databases
+# Log files
 *.log
-*.sql
-*.sqlite
+
+# htaccess
+/.htaccess
+
+# All plugins
+#
+# Note: If you wish to whitelist plugins,
+# uncomment the next line
+#/wp-content/plugins
+
+# All themes
+#
+# Note: If you wish to whitelist themes,
+# uncomment the next line
+#/wp-content/themes

--- a/templates/WordPress.gitignore
+++ b/templates/WordPress.gitignore
@@ -1,5 +1,4 @@
 # ignore everything in the root except the "wp-content" directory.
-/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:

--- a/templates/WordPress.gitignore
+++ b/templates/WordPress.gitignore
@@ -1,24 +1,48 @@
-# ignore everything in the root except the "wp-content" directory.
-/*
-!wp-content/
+# Wordpress - ignore core, configuration, examples, uploads and logs.
+# https://github.com/github/gitignore/blob/master/WordPress.gitignore
 
-# ignore everything in the "wp-content" directory, except:
-# "mu-plugins", "plugins", "themes" directory
-wp-content/*
-!wp-content/mu-plugins/
-!wp-content/plugins/
-!wp-content/themes/
+# Core
+#
+# Note: if you want to stage/commit WP core files
+# you can delete this whole section/until Configuration.
+/wp-admin/
+/wp-content/index.php
+/wp-content/languages
+/wp-content/plugins/index.php
+/wp-content/themes/index.php
+/wp-includes/
+/index.php
+/license.txt
+/readme.html
+/wp-*.php
+/xmlrpc.php
 
-# ignore these plugins
-wp-content/plugins/hello.php
+# Configuration
+wp-config.php
 
-# ignore specific themes
-wp-content/themes/twenty*/
+# Example themes
+/wp-content/themes/twenty*/
 
-# ignore node dependency directories
-node_modules/
+# Example plugin
+/wp-content/plugins/hello.php
 
-# ignore log files and databases
+# Uploads
+/wp-content/uploads/
+
+# Log files
 *.log
-*.sql
-*.sqlite
+
+# htaccess
+/.htaccess
+
+# All plugins
+#
+# Note: If you wish to whitelist plugins,
+# uncomment the next line
+#/wp-content/plugins
+
+# All themes
+#
+# Note: If you wish to whitelist themes,
+# uncomment the next line
+#/wp-content/themes

--- a/templates/WordPress.gitignore
+++ b/templates/WordPress.gitignore
@@ -1,48 +1,24 @@
-# Wordpress - ignore core, configuration, examples, uploads and logs.
-# https://github.com/github/gitignore/blob/master/WordPress.gitignore
+# ignore everything in the root except the "wp-content" directory.
+/*
+!wp-content/
 
-# Core
-#
-# Note: if you want to stage/commit WP core files
-# you can delete this whole section/until Configuration.
-/wp-admin/
-/wp-content/index.php
-/wp-content/languages
-/wp-content/plugins/index.php
-/wp-content/themes/index.php
-/wp-includes/
-/index.php
-/license.txt
-/readme.html
-/wp-*.php
-/xmlrpc.php
+# ignore everything in the "wp-content" directory, except:
+# "mu-plugins", "plugins", "themes" directory
+wp-content/*
+!wp-content/mu-plugins/
+!wp-content/plugins/
+!wp-content/themes/
 
-# Configuration
-wp-config.php
+# ignore these plugins
+wp-content/plugins/hello.php
 
-# Example themes
-/wp-content/themes/twenty*/
+# ignore specific themes
+wp-content/themes/twenty*/
 
-# Example plugin
-/wp-content/plugins/hello.php
+# ignore node dependency directories
+node_modules/
 
-# Uploads
-/wp-content/uploads/
-
-# Log files
+# ignore log files and databases
 *.log
-
-# htaccess
-/.htaccess
-
-# All plugins
-#
-# Note: If you wish to whitelist plugins,
-# uncomment the next line
-#/wp-content/plugins
-
-# All themes
-#
-# Note: If you wish to whitelist themes,
-# uncomment the next line
-#/wp-content/themes
+*.sql
+*.sqlite


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The `WordPress.gitignore` state over at github/gitignore is at royal mess. This PR updates the `.gitignore` (following my proposal on PR [github/gitignore#3295](https://github.com/github/gitignore/pull/3295) which has since become _radio silent_) and disables/removes the sync with github/gitignore for `WordPress.gitignore`—at least until github/gitignore sorts out that gitignore.

Please see below for context and the explanation of my reasoning and proposal.

### Why update `WordPress.gitignore`?

[Current github/gitignore `WordPress.gitignore`](https://github.com/github/gitignore/blob/master/WordPress.gitignore) is broken for now more than 2 years following up a careless and bad PR being merged, [github/gitignore#2972](https://github.com/github/gitignore/pull/2972). It completely doesn't work (allows staging of config files with secrets [[1](https://github.com/github/gitignore/pull/2972#issuecomment-525248607)], staging of a complete WP install [[2](https://github.com/github/gitignore/pull/2972#issuecomment-576938421)], etc), and apart from not being usable it has, IMHO, many other issues that go against the spirit of both github/gitignore and on a broader extent gitignore.io.

What this means is that both [github/gitignore](https://github.com/github/gitignore) and to a broader extent [toptal/gitignore](https://github.com/toptal/gitignore), [gitignore.io](http://gitignore.io), its [API](https://docs.gitignore.io/use/api) (along with all dependent projects), etc, simply put, **currently don't have a solution for one of the most popular technology powering the Web nowadays**, and I'm sure that by now this is known for many people that use WordPress and rely/relied on github/gitignore and gitignore.io.

### Background

I and my company have on our development process for long relied on gitignore.io to bootstrap up to date gitignores for our projects, namely our WordPress ones, and [the version before the abovementioned github/gitignore#2972 PR](https://github.com/rohanvakharia/gitignore/blob/1a9f616ce525987555d43c72d59eb830d1856bd7/WordPress.gitignore) performed rather well—it kept most of the installation and WP Core files, mostly ignoring uploads and other config files, notwithstanding its option to commit WP Core it worked quite well.

But since that PR, it broke `WordPress.gitignore` for everyone—which led us to stop relying on gitignore.io for the WP part of our gitignores, something which I suspect lot of teams and WP developers did as well.

Moreover, that PR seems to have been based off a popular and rather opinionated proposal for a monolithic WordPress [[3](https://gist.github.com/salcode/9940509)][[4](https://salferrarello.com/wordpress-gitignore/)] but was badly and haphazardly copied. Also, I think IMO that this monolithic approach might not be the best for the 'modular' approach of  gitignore.io and goes against the contributing guidelines of github/gitignore also (scope).

### Fixing this

Since then there have been 10 attempts (PRs) to try and fix this, some better/more interesting than others, but most certainly from people facing the same issue I explained:

- [github/gitignore#3093](https://github.com/github/gitignore/pull/3093) (open, no activity for more than a year)
- [github/gitignore#3125](https://github.com/github/gitignore/pull/3125) (open, no activity for more than a year)
- [github/gitignore#3282](https://github.com/github/gitignore/pull/3282) (closed by contributor in favor of another one)
- [github/gitignore#3293](https://github.com/github/gitignore/pull/3293) (closed by contributor in favor of another one)
- [github/gitignore#3295](https://github.com/github/gitignore/pull/3295) (open, no response by contributors)
- [github/gitignore#3378](https://github.com/github/gitignore/pull/3378) (open, duplicate of another one)
- [github/gitignore#3388](https://github.com/github/gitignore/pull/3388) (closed by author in favor of another one)
- [github/gitignore#3438](https://github.com/github/gitignore/pull/3438) (open, duplicate of another one)
- [github/gitignore#3480](https://github.com/github/gitignore/pull/3480) (closed by author)
- [github/gitignore#3655](https://github.com/github/gitignore/pull/3655) (open, duplicate of another one)

None so far has produced a fix to put back a working `WordPress.gitignore` back into github/gitignore and subsequently gitignore.io, and address the underlying issues that I think this git ignore has.

### Monolithic vs modular gitignores

At a first sight one of the biggest issues that [github/gitignore#2972](https://github.com/github/gitignore/pull/2972) PR has is due to the fact that is based off a proposal for a [WordPress gitignore](https://salferrarello.com/wordpress-gitignore) that is, at lack of a better term, **monolithic**—it's a single gitignore ready to use, that covers all the files needed for WordPress, including OS files and other files outside of WP scope, eg: node/npm modules, etc.

Since this gitignore is monolithic, its author also opted to base it off on a 'catch-all' approach, doing a very eager ignoring of files on the root folder and then adding excludes for several items.

On the other way, gitignore.io and even github/gitignore in a way (Globals) rely and structure the gitignores around the idea of **modularity**—one can append and mix several git ignore templates at various levels OS/Language/package manager/editor/etc to build a git ignore solution for his project. And the contributing guidelines of these projects state the changes have to be on the scope of the language/tool/editor and if they pertain to another scope, those should be added in the appropriate gitignore template for that scope.

### Issues with current WP gitignore

- **It is supposed to work with a catch-all approach** (`/*`, ignore everything from root), and this on a modular gitignore approach can conflict with other git ignores for other scopes one might want to join to his project. To achieve this modularity the gitignore should be directed to be declarative (ignoring the files/folders needed, instead of ignoring all and excluding certain files/folders).
- **Is ignoring node/npm modules folder** which it something for the scope/gitignore for Node.
- **Ignores `*.sql` files** which is a preference of the author dev workflow, that shouldn't be imposed on other projects. The idea behind both gitignore.io and github/gitignore is provide sensible defaults and then one can add/append the lines that make sense for the context of a particular project, workflow, etc.

### Aim of WP gitignore proposal

- Address the minimal/most common/overly used scenario for WordPress, meaning it's not extensive on the specific file types and plugin folders to be ignored (but I believe stacks can be explored later to extend this gitignore if need be).
- Opted to ignore WP Core, and allow all themes (except default ones) and plugins, but added comments and sections that can be removed/uncommented to achieve a different approach, etc. (This is debatable too though.)
- Employ a declarative approach on the files/folders it should ignore to allow to be used alongside/mixed with other gitignores.

### Closing remarks

It is clear that this repository relies heavily on the sync with github/gitignore, and [as the fork blog post](https://blog.joeblau.com/gitignore-io-template-fork) states the fork is intended to extend GitHub gitignore list, but in this case (WordPress gitignore) I fear that github/gitignore isn't in a good place at the moment, and that WordPress is a very important piece on the toolbox of many developers, sites and businesses that gitignore.io shouldn't be leaving out.

So until the WordPress gitignore stabilizes on the github/gitignore I propose we stop syncing this file with that repository, and commit a fixed gitignore to the gitignore.io so developers, teams and projects can continue to rely on it to bootstrap and setup their projects.