### PR TITLE
Ignore Bazel IntelliJ plugin config directory

### DIFF
--- a/templates/Bazel.gitignore
+++ b/templates/Bazel.gitignore
@@ -4,3 +4,6 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
+
+# Configuration directory for the Bazel IntelliJ plugin.
+.ijwb/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The `.ijwb` directory contains the workspace configuration for the Bazel IntelliJ plugin, which is configured individually by each developer and typically not committed (each developer will have their own "workspace view" selecting specific targets to enable). See https://blog.bazel.build/2019/09/29/intellij-bazel-sync.html

I ignored `.ijwb` at all levels in the tree because a repository using Bazel will sometimes contain nested Bazel workspaces imported into the root with `local_repository(..)`, and IntelliJ may be used to open a nested workspace in isolation producing a `.ijwb` directory in that workspace.