### PR TITLE
Add ansible tower template

### DIFF
--- a/templates/AnsibleTower.gitignore
+++ b/templates/AnsibleTower.gitignore
@@ -1,0 +1,24 @@
+# Ansible runtime and backups
+*.original
+*.tmp
+*.bkp
+*.retry
+*.*~
+
+# Tower runtime roles 
+roles/**
+!roles/requirements.yml
+
+# Avoid plain-text passwords 
+*pwd*
+*pass*
+*password*
+*.txt
+
+# Exclude all binaries
+*.bin
+*.jar
+*.tar
+*.zip
+*.gzip
+*.tgz


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [X] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

The current Ansible template is useful only for Ansible Core (running on local laptop) not Ansible Tower which requires a more complicated gitignore. I've created another file here but you could merge this into the Ansible template if desired.