### PR TITLE
Update hugo.gitignore

### DIFF
--- a/templates/Hugo.gitignore
+++ b/templates/Hugo.gitignore
@@ -1,6 +1,7 @@
 # Generated files by hugo
 /public/
 /resources/_gen/
+/assets/jsconfig.json
 hugo_stats.json
 
 # Executable may be added to repository


### PR DESCRIPTION
## Update

- [x] Template - Update existing `.gitignore` template

## Details

Hugo recently introduced a jsconfig.json containing information about the local location of Go modules in use. The info in that file is not portable (see below) and the file should be ignored.

sample content 

```
{
 "compilerOptions": {
  "baseUrl": ".",
  "paths": {
   "*": [
    "../../../../../../tmp/hugo_cache/modules/filecache/modules/pkg/mod/github.com/popperjs/popper-core@v2.9.2+incompatible/src/*",
    "../../../../../../tmp/hugo_cache/modules/filecache/modules/pkg/mod/github.com/twbs/bootstrap@v5.0.0+incompatible/dist/*"
   ]
  }
 }
}
```

info about the file: https://gohugo.io/hugo-pipes/js/#import-js-code-from-assets (last paragraph in this section)