### PR TITLE
Add .sonarqube folder to SonarQube ignore

### DIFF
--- a/templates/SonarQube.gitignore
+++ b/templates/SonarQube.gitignore
@@ -3,6 +3,7 @@
 # https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
 # Sonar Scanner working directories
 .sonar/
+.sonarqube/
 .scannerwork/
 
 # http://www.sonarlint.org/commandline/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The dotnet-sonarscanner tool uses a .sonarqube folder, which should be ignored