### PR TITLE
Add `zig-out` directory for the Zig programming language

### DIFF
--- a/templates/zig.gitignore
+++ b/templates/zig.gitignore
@@ -1,6 +1,7 @@
 # Zig programming language
 
 zig-cache/
+zig-out/
 build/
 build-*/
 docgen_tmp/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

An update to the Zig programming language compiler changed the behaviour of the
`LibExeObjStep.install`  command to generate the resulting files in a `zig-out` directory
instead of the old `zig-cache/bin` directory.