### PR TITLE
Add .classpath to Eclipse.gitignore

### DIFF
--- a/templates/Eclipse.gitignore
+++ b/templates/Eclipse.gitignore
@@ -28,6 +28,9 @@ local.properties
 # Java annotation processor (APT)
 .factorypath
 
+# JDT-specific (Java Developments Tools)
+.classpath
+
 # PDT-specific (PHP Development Tools)
 .buildpath
 


### PR DESCRIPTION
The JDT's .classpath file is not necessarily portable

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

### Update

- [X] Template - Update existing `.gitignore` template

## Details

As the generated .classpath file is not necessarily portable, this PullRequest proposes adding it to the default list of ignored files.