### PR TITLE
Ignore dotenv in dart

### DIFF
--- a/templates/Dart.patch
+++ b/templates/Dart.patch
@@ -1,0 +1,2 @@
+# dotenv environment variables file
+.env


### PR DESCRIPTION
# Pull Request

### Update

- [ ] Template - Update existing `Dart.gitignore` template

## Details

**Reasons for making this change:**
Ignoring dotenv files to avoid leaking secrets on Github

**Links to documentation supporting these rule changes:**
Reason for ignoring the dotenv file on GitHub
https://blog.gitguardian.com/secrets-api-management/#git-ignore
dotenv package on pub.dev
https://pub.dev/packages/flutter_dotenv

## Related pull request in Github/gitignore - (Created by me)
[#3709-Github](https://github.com/github/gitignore/pull/3709)