### PR TITLE
Add .webpack directory of Serverless Webpack to Node.gitignore

### DIFF
--- a/templates/Node.patch
+++ b/templates/Node.patch
@@ -1,0 +1,2 @@
+# Serverless Webpack directories
+.webpack/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details
Add the directory `.webpack` that Serverless Webpack creates by default.

Serverless Webpack
https://github.com/serverless-heaven/serverless-webpack

> **Output**
> Note that, if the output configuration is not set, it will automatically be generated to write bundles in the .webpack directory. If you set your own output configuration make sure to add a libraryTarget for best compatibility with external dependencies:

----

2021.08.12 
Changed from template update to Patch.