### PR TITLE
Ignore Eclipse .project and .classpath when using a build tool (Maven or Gradle)

### DIFF
--- a/templates/Code-Java.gitignore
+++ b/templates/Code-Java.gitignore
@@ -1,5 +1,0 @@
-# Language Support for Java(TM) by Red Hat extension for Visual Studio Code - https://marketplace.visualstudio.com/items?itemName=redhat.java
-
-.project
-.classpath
-factoryConfiguration.json

--- a/templates/Java-Web.gitignore
+++ b/templates/Java-Web.gitignore
@@ -1,2 +1,0 @@
-## ignoring target file
-target/

--- a/templates/Maven.patch
+++ b/templates/Maven.patch
@@ -1,6 +1,4 @@
-**/build/
-
-# Eclipse Gradle plugin generated files
+# Eclipse m2e generated files
 # Eclipse Core
 .project
 # JDT-specific (Eclipse Java Development Tools)

--- a/templates/m2e.gitignore
+++ b/templates/m2e.gitignore
@@ -1,2 +1,0 @@
-.classpath
-.project


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [X] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

I see there has been a lot of back and forth regarding the `.project` and `.classpath` files for Java projects in Eclipse or VS Code.  What it all basically comes down to is
- An Eclipse/VS Code project that *does not* use a build tool (Maven or Gradle) *should* have these files under source control
- A project that *uses a build tool* like Maven or Gradle *should ignore* these files, since they are generated by the build tool plugin for Eclipse

Therefore, these files should be ignored for Maven and Gradle (and *not* Eclipse or Code)

The PR
- Adds these files to the Maven.patch (Created) and Gradle.patch
- Delete Java-Web.gitignore - all the entries are covered by Maven.gitignore
- Delete m2e.gitignore - all the entries are covered by Maven.gitignore
- Delete Code-Java.gitignore
  - `.project` and `.classpath` are covered by the Maven.patch and Gradle.patch
  - `factoryConfiguration.json` I am not able to determine where this file would be generated or created, nor why it should be ignored
