### PR TITLE
Remove redundant Makefile from Autotools+strict.patch

### DIFF
--- a/templates/Autotools+strict.patch
+++ b/templates/Autotools+strict.patch
@@ -1,3 +1,2 @@
 # Generated source files
 configure
-Makefile


### PR DESCRIPTION
More files to be ignored were added for autotools+strict in #172, and
the same idea bled over into +strict's parent in 3c8f56ca so the
Makefile line is now redundant and seems to be being stripped on
gitignore.io anyways.