### PR TITLE
Set timeouts to all GHA workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
no-jira

### Description
After the GitHub/GitHub Actions outage, it became really important to have all of our workflows with timeouts set. Otherwise, GHA will use its default timeout, which is 6 hours. This PR sets timeouts for all jobs that didn't have a value set.
