### PR TITLE
fix: reintroduces `.stylelintcache` to Node.gitignore

### DIFF
--- a/templates/Node.patch
+++ b/templates/Node.patch
@@ -1,2 +1,5 @@
 # Serverless Webpack directories
 .webpack/
+
+# Optional stylelint cache
+.stylelintcache


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details


Reintroduces ignore to [stylelint's](https://github.com/stylelint/stylelint) cache. Defaults to [`.stylelintcache`](https://stylelint.io/user-guide/usage/options#cache)
Which was first added in #356 and then removed in #401 (by accident I presume).

PR also added to https://github.com/github/gitignore/pull/3829