### PR TITLE
Organize nuxtjs templates

### DIFF
--- a/.moban.yaml
+++ b/.moban.yaml
@@ -147,7 +147,7 @@ targets:
   - templates/Node.gitignore: Node.gitignore
   - templates/Nohup.gitignore: Nohup.gitignore
   - templates/NotepadPP.gitignore: NotepadPP.gitignore
-  - templates/Nuxt.gitignore: Nuxt.gitignore
+  - templates/Nuxtjs.gitignore: Nuxtjs.gitignore
   - templates/NWjs.gitignore: NWjs.gitignore
   - templates/Objective-C.gitignore: Objective-C.gitignore
   - templates/OCaml.gitignore: OCaml.gitignore

--- a/templates/Nuxt.gitignore
+++ b/templates/Nuxt.gitignore
@@ -1,9 +1,0 @@
-# gitignore template for Nuxt.js projects
-#
-# Recommended template: Node.gitignore
-
-# Nuxt build
-.nuxt
-
-# Nuxt generate
-dist

--- a/templates/Nuxtjs.gitignore
+++ b/templates/Nuxtjs.gitignore
@@ -1,9 +1,3 @@
-# dependencies
-node_modules
-
-# logs
-npm-debug.log
-
 # Nuxt build
 .nuxt
 


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

This pr examines and integrates two templates `Nuxt` and `Nuxtjs`. Both templates point at the same js framework "NuxtJS", so there is no need to have two separate templates.

* This removes `Nuxt` and keeps `Nuxtjs` as I prefer the full name, but any opinions are welcome.
* This removes unnecessary lines in the `Nuxtjs` which belongs to `Node` template, not `Nuxtjs` template.
* `.moban.yaml` is updated following the file changes above, but I have no background knowledge for `.moban.yaml`, so any advices are welcome.

I also examined former commits cf0b6a8, github/gitignore@d1fa5ff to make this change.

This resolves toptal/gitignore.io#550