### PR TITLE
Add .der certificate extension

### DIFF
--- a/templates/certificates.gitignore
+++ b/templates/certificates.gitignore
@@ -2,4 +2,5 @@
 *.key
 *.crt
 *.cer
+*.der
 *.priv


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

This extension is used for binary certificates.