### PR TITLE
Obsidian (knowledge base)

### DIFF
--- a/templates/Obsidian.gitignore
+++ b/templates/Obsidian.gitignore
@@ -1,0 +1,2 @@
+# config dir
+.obsidian/


### PR DESCRIPTION
### New

- [X] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

## Details

Adds a template for the Obsidian knowledge base editor/manager.
https://obsidian.md/

The template excludes a directory holding several configuration files, which are relevant for a local editor setup only (hotkeys, appearance, etc.).