### PR TITLE
Add SvelteKit generated directories to Node.patch

### DIFF
--- a/templates/Node.patch
+++ b/templates/Node.patch
@@ -3,3 +3,6 @@
 
 # Optional stylelint cache
 .stylelintcache
+
+# SvelteKit build / generate output
+.svelte-kit


### PR DESCRIPTION
# Pull Request

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details
Add directories to be generated by SvelteKit.

SvelteKit • The fastest way to build Svelte apps
https://kit.svelte.dev/

There is no explicit mention of the output directory in the documentation, but in fact `.svelte-kit` and `build` are created.

There is also a note about the output directory for adapter creation, as follows
> If possible, we recommend putting the adapter output under the build/ directory with any intermediate output placed under '.svelte-kit/' + adapterName.
https://kit.svelte.dev/docs#writing-an-adapter