### PR TITLE
Add asterisk to enable exclusion of custom/specific files inside .idea directory

### DIFF
--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -1,7 +1,7 @@
 # Ignores the whole .idea folder and all .iml files
 # See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
 
-.idea/
+.idea/*
 
 # Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
 


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Withouth askterisk one cannot exclude folders like ".idea/runConfigurations" from gitignore. Checking shared run configurations into repo is a common practice for many teams. With asterisk folders like these can be easily excluded in the "### Custom declarations ###" section located at the end of the generated .gitignore. Detailed discussion: https://gist.github.com/hieblmedia/9318457

Example:

```regex
### Intellij+all Patch ###
# Ignores the whole .idea folder and all .iml files
# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360

.idea/*

...

### Custom declarations ###

# Share run configurations
!/.idea/runConfigurations/
```