### PR TITLE
Include Angular's persistent build cache

### DIFF
--- a/templates/Angular.gitignore
+++ b/templates/Angular.gitignore
@@ -20,6 +20,7 @@ libpeerconnection.log/
 npm-debug.log
 testem.log
 typings/
+.angular/
 
 # e2e
 e2e/*.js


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Angular v12.1 added an experimental caching of build information. In v13, it was enabled by default for new projects.
See https://github.com/angular/angular-cli/issues/21545 and https://angular.io/cli/cache for details.