### PR TITLE
Add `.hugo_build.lock` to `Hugo.gitignore`

### DIFF
--- a/templates/Hugo.gitignore
+++ b/templates/Hugo.gitignore
@@ -1,7 +1,6 @@
 # Generated files by hugo
 /public/
 /resources/_gen/
-.hugo_build.lock
 
 # Executable may be added to repository
 hugo.exe

--- a/templates/Hugo.patch
+++ b/templates/Hugo.patch
@@ -1,0 +1,9 @@
+# Generated files by hugo
+/public/
+/resources/_gen/
+.hugo_build.lock
+
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

This PR adds `.hugo_build.lock` to `Hugo.patch` ~~`Hugo.gitignore`~~, which has been introduced since Hugo v0.89.0 (cf. [the release notes](https://gohugo.io/news/0.89.0-relnotes/#notes)).