### PR TITLE
Add .gdb_history for C and C++

### DIFF
--- a/templates/C++.gitignore
+++ b/templates/C++.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# GDB history file
+.gdb_history

--- a/templates/C.gitignore
+++ b/templates/C.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# GDB history file
+.gdb_history


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details
[GDB (GNU debugger)](https://www.gnu.org/software/gdb/) is frequently used with C and C++, and it generates a .gdb_history file with a history of commands used n the folder you run it from.

It's a perfect candidate for putting into your .gitignore when doing C and C++ development.