### PR TITLE
Update Erlang.gitignore

### DIFF
--- a/templates/Erlang.patch
+++ b/templates/Erlang.patch
@@ -1,0 +1,1 @@
+rebar3.crashdump


### PR DESCRIPTION
##  Update

- [x] Template - Update existing `.gitignore` template

## Details

The rebar3 is the default Erlang build tool. Sometimes it would
generate rebar3.crashdump in the workspace. The rebar3.crashdump should
be excluded from project.