### PR TITLE
Remove Eclipse .project and .classpath from Maven.patch and Gradle.patch

### DIFF
--- a/templates/Gradle.patch
+++ b/templates/Gradle.patch
@@ -1,7 +1,1 @@
 **/build/
-
-# Eclipse Gradle plugin generated files
-# Eclipse Core
-.project
-# JDT-specific (Eclipse Java Development Tools)
-.classpath

--- a/templates/Maven.patch
+++ b/templates/Maven.patch
@@ -1,5 +1,0 @@
-# Eclipse m2e generated files
-# Eclipse Core
-.project
-# JDT-specific (Eclipse Java Development Tools)
-.classpath


### PR DESCRIPTION
`.project` and `.classpath` have been incorporated directly into the github/gitignore
Maven and Gradle templates (https://github.com/github/gitignore/pull/3920),
and therefore no longer need to be defined in the Maven and Gradle patch files as well.

This partially reverts #403

This does depend on the templates being synced with the latest on github/gitignore.  It's not clear to me if that is something that needs to be included in this PR, or if that is done by another process.  Please let me know if I need do add anything to this PR