### PR TITLE
Clean up AndroidStudio template

### DIFF
--- a/templates/AndroidStudio.gitignore
+++ b/templates/AndroidStudio.gitignore
@@ -92,15 +92,6 @@ obj/
 .idea/jarRepositories.xml
 .idea/navEditor.xml
 
-# OS-specific files
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
-
 # Legacy Eclipse project files
 .classpath
 .project


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

Clean up `AndroidStudio.gitignore` template by removing irrelevant entries: there are more exhaustive `macOS.gitignore` and `Windows.gitignore` for OS-specific files, so no need to try to keep a copy here, I guess, which is by the way an incomplete one :)