### PR TITLE
Straighten JetBrains+all out

### DIFF
--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -1,14 +1,7 @@
-# Ignores the whole .idea folder and all .iml files
-# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
 
 .idea/*
 
-# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
-
-*.iml
-modules.xml
-.idea/misc.xml
-*.ipr
-
-# Sonarlint plugin
-.idea/sonarlint
+!.idea/codeStyles
+!.idea/runConfigurations


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

Feels like this file went a little bit [bankrupt](https://www.emacswiki.org/emacs/DotEmacsBankruptcy) 😅

Line 4 was already covering everything that went after.

This change intends to clean up this file and make its purpose obvious: ignore _all_ IDEA stuff (as it was before this change) except for what needs to be shared explicitly (like code style settings and run configurations).

See commit message for references.