### PR TITLE
enhance python ignore file to not ignore nested lib directory

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+lib/*
 !**/lib
 lib64/
 parts/

--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!**/lib
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

First, this is a fantastic tool.

I get it that there might be some distribution/packaging processes that create a `lib` directory that should not be committed to source code.

I do not believe that the use of `lib` as a folder name, in general, should be ignored.

I couldn't figure out why my CI tests kept failing until I noticed the lib folder was not on Github.

As a compromise, could we ignore the top level folder, but allow all folders not in the root to be committed?

Thanks!