### PR TITLE
Fix: do not ignore "*target/" subdirectories.

### DIFF
--- a/templates/Maven.gitignore
+++ b/templates/Maven.gitignore
@@ -1,4 +1,4 @@
-target/
+/target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Recently I ran into a problem: I created a Java package "*.target.*" and gitignore it when committing. It turned out it was because of this line.