### PR TITLE
Add LaTeX's hypdoc aux files

### DIFF
--- a/templates/TeX.gitignore
+++ b/templates/TeX.gitignore
@@ -138,6 +138,9 @@ acs-*.bib
 *.trc
 *.xref
 
+# hypdoc
+*.hd
+
 # hyperref
 *.brf
 


### PR DESCRIPTION
### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

The LaTeX's [hypdoc](https://ctan.org/pkg/hypdoc) package produces `.hd` files upon compiling the document. They are unnecessary in a repository.