### PR TITLE
[SAT-2287] Team name change to Utilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @toptal/site-acquisition-eng
+* @toptal/ext-utilities-eng


### PR DESCRIPTION
[SAT-2287](https://toptal-core.atlassian.net/browse/SAT-2287)

### Description

Changing the team name from Site Acquisition to Utilities.

Code owners will be `toptal/ext-utilities-eng`.

> Don't merge this before 2022-09-05.
