### PR TITLE
feat: undo changes to vscode patch

### DIFF
--- a/templates/VisualStudioCode.patch
+++ b/templates/VisualStudioCode.patch
@@ -1,9 +1,3 @@
 # Ignore all local history of files
 .history
 .ionide
-
-# Support for Project snippet scope
-.vscode/*.code-snippets
-
-# Ignore code-workspaces
-*.code-workspace


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or updated

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how the template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

In this PR I am reverting the changes created in [this PR](https://github.com/toptal/gitignore/pull/448#issuecomment-1275812446) and in this commit 90a23ed7e75a3d19cae1898b65a0fa64afc1b27e. 

The reason I enable committing of the `workspace-settings` is [this](https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings) official documentation that mentions that project settings may be shared between the participants of the project.

The reason I enable committing of the `code-snippets` is pretty much [the same](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_project-snippet-scope). We want by default to enable users to share snippets