### PR TITLE
feat: remove redundant and deprecated rules for Go

### DIFF
--- a/templates/Go.patch
+++ b/templates/Go.patch
@@ -1,2 +1,0 @@
-/vendor/
-/Godeps/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Since the release of [Go Modules](https://go.dev/blog/using-go-modules) the vendor path has been added to `Go.gitignore` making it's presence in `Go.patch` redundant. Also, both [godep](https://github.com/tools/godep) and [dep](https://github.com/golang/dep) have been deprecated therefore ignoring the Godeps folder is not useful anymore.