### PR TITLE
Remove fastlane from Objective-C and Swift gitignores

### DIFF
--- a/templates/Objective-C.gitignore
+++ b/templates/Objective-C.gitignore
@@ -48,18 +48,6 @@ DerivedData/
 
 Carthage/Build/
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output
-
 # Code Injection
 #
 # After new code Injection tools there's a generated folder /iOSInjectionProject

--- a/templates/Swift.gitignore
+++ b/templates/Swift.gitignore
@@ -70,18 +70,6 @@ Carthage/Build/
 Dependencies/
 .accio/
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output
-
 # Code Injection
 #
 # After new code Injection tools there's a generated folder /iOSInjectionProject


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

_fastlane_ is an additional component and not always part of Objective-C or Swift development.
Also it was separated into `fastlane.gitignore` so people who use _fastlane_ can generate needed _gitignore_ file by adding _fastlane_ to the parameters.