### PR TITLE
Add autohotkey gitignore file to templates.

### DIFF
--- a/templates/Autohotkey.gitignore
+++ b/templates/Autohotkey.gitignore
@@ -1,0 +1,47 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

An Autohotkey gitignore file which specifies the following as untracked files that Git should ignore:
- Windows image file caches
- Folder config file
- Recycle Bin used on file shares
- Windows Installer files
- Windows shortcuts
- Operating System Files
- Thumbnails
- Files that might appear in the root of a volume
- Directories potentially created on remote AFP share