### PR TITLE
Update PHPCodeSniffer.gitignore

### DIFF
--- a/templates/PHPCodeSniffer.gitignore
+++ b/templates/PHPCodeSniffer.gitignore
@@ -1,4 +1,5 @@
 # CodeSniffer
+phpcs.xml
 
 /vendor/*
 /wpcs/*


### PR DESCRIPTION
To be consistent with PHPUnit rules. Project/library settings should be stored in phpcs.xml.dist

### Update

- [x] Template - Update existing `.gitignore` template
