### PR TITLE
Add missing Nuxt 3's generated dirs

### DIFF
--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -90,6 +90,9 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.nuxt-*
+.output
+.gen
 
 # Gatsby files
 .cache/

--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -90,9 +90,6 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
-.nuxt-*
-.output
-.gen
 
 # Gatsby files
 .cache/

--- a/templates/NuxtJS.gitignore
+++ b/templates/NuxtJS.gitignore
@@ -1,0 +1,6 @@
+# Generated dirs
+dist
+.nuxt
+.nuxt-*
+.output
+.gen

--- a/templates/NuxtJS.gitignore
+++ b/templates/NuxtJS.gitignore
@@ -4,3 +4,10 @@ dist
 .nuxt-*
 .output
 .gen
+
+
+# Node dependencies
+node_modules
+
+# System files
+*.log

--- a/templates/NuxtJS.gitignore
+++ b/templates/NuxtJS.gitignore
@@ -5,7 +5,6 @@ dist
 .output
 .gen
 
-
 # Node dependencies
 node_modules
 

--- a/templates/Nuxtjs.gitignore
+++ b/templates/Nuxtjs.gitignore
@@ -1,5 +1,0 @@
-# Nuxt build
-.nuxt
-
-# Nuxt generate
-dist


### PR DESCRIPTION
## Update

- [x] Template - Update existing `.gitignore` template

## Description
I updated the Nuxt section to include the new Nuxt 3 generated folders.

## References
- Official [.gitignore](https://github.com/nuxt/nuxt/blob/main/.gitignore#L22-L24) file.
- Nuxt Team's recommended .gitignore [entries](https://nuxt.com/docs/guide/directory-structure/gitignore#git-ignore-file).