### PR TITLE
Add preprocessor output to C and C++ templates

### DIFF
--- a/templates/C++.gitignore
+++ b/templates/C++.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+# Preprocessor output
+*.i
+
 # Compiled Object files
 *.slo
 *.lo

--- a/templates/C.gitignore
+++ b/templates/C.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+# Preprocessor output
+*.i
+
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

C and C++ projects may generate preprocessed files as part of build project.
These files are suposed to be deleted at the end of process, but may stand there sometimes.
Reference: https://pvs-studio.com/en/blog/terms/0076/