### PR TITLE
Add Nix gitignore template

### DIFF
--- a/templates/Nix.gitignore
+++ b/templates/Nix.gitignore
@@ -1,0 +1,3 @@
+# Results directory from a build (or build of attribute set)
+result
+result-*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

Ignores for the [Nix](https://nixos.org/) language. There are only two commonly ignored symlinks, as seen for example in [this gitignore](https://github.com/hercules-ci/gitignore.nix/blob/master/.gitignore).

Essentially, when you run a `nix build` command, it will build according to whatever file (likely a `default.nix` or a `flake.nix`) in the Nix store and then symlink the resulting final build into the local folder under the name `result`. If there are multiple build results, then these symlinks are instead named `result-1`, `result-2`, etc. Since these are links to changing build directories, they are ignored.