### PR TITLE
Update NuxtJS.gitignore from NuxtJS template

### DIFF
--- a/templates/NuxtJS.gitignore
+++ b/templates/NuxtJS.gitignore
@@ -1,12 +1,23 @@
-# Generated dirs
-dist
-.nuxt
-.nuxt-*
+# Nuxt dev/build outputs
 .output
-.gen
+.nuxt
+.nitro
+.cache
+dist
 
 # Node dependencies
 node_modules
 
-# System files
+# Logs
+logs
 *.log
+
+# Misc
+.DS_Store
+.fleet
+.idea
+
+# Local env files
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
This update is based on the template that is generated using `nuxti` the Nuxt CLI. Do note that this is based on Nuxt 3 which is quite a big change from Nuxt 2 so people using Nuxt 2 might not need all of the items in this gitignore.

Nevertheless, I am making this PR based on the Nuxt CLI which you can see (here)[https://github.com/nuxt/starter/blob/templates/templates/v3.json]. The URL in the `tar` property is contains the actual template and the PR is based on the gitignore present in that template.

# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

*replace this section with links and/or info about the proposed request*