### PR TITLE
fix: strip VSCode globs from VisualStudio.gitignore

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -370,22 +370,8 @@ healthchecksdb
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
 
-# Ionide (cross platform F# VS Code tools) working folder
-.ionide/
-
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-
-# VS Code files for those working on multiple tools
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-*.code-workspace
-
-# Local History for Visual Studio Code
-.history/
 
 # Windows Installer files from build outputs
 *.cab


### PR DESCRIPTION
At some point, github:gitignore "contaminated" its VisualStudio.gitignore with some Visual Studio *Code* rules...some of which were intentionally removed from our VisualStudioCode.gitignore.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

- https://github.com/toptal/gitignore/pull/487
- https://github.com/toptal/gitignore/commit/41bf38845d24ebabec2821cb1d87a7ec814d8d8b