### PR TITLE
Create Debian.gitignore

### DIFF
--- a/templates/Debian.gitignore
+++ b/templates/Debian.gitignore
@@ -1,0 +1,15 @@
+# gitignore template for creating Debian packages
+# website: https://wiki.debian.org/HowToPackageForDebian
+
+# It's also strongly recommended to include project specific names in this
+# gitignore file, as the Debian packaging scripts will create directories for
+# the packages' content. Just uncomment and modify the line below:
+#debian/<package_name>/
+
+debian/autoreconf.*
+debian/debhelper-build-stamp
+debian/files
+debian/tmp/
+debian/*.debhelper
+debian/*.log
+debian/*.substvars


### PR DESCRIPTION
## New
- [X] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

## Details
Add .gitignore template for Debian packaging build files created by debhelper utilities.

See also: https://wiki.debian.org/HowToPackageForDebian

I posted a [similar pull request](https://github.com/github/gitignore/pull/4311) to `github/gitignore`, but they do not respond.

@quicoa contributed improvements, thank you for that.
