### PR TITLE
Don't ignore required plugins in JetBrains+all

### DIFF
--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -1,7 +1,8 @@
-# Ignore everything but code style settings and run configurations
-# that are supposed to be shared within teams.
+# Ignore everything but code style settings, run configurations and
+# external dependencies that are supposed to be shared within teams.
 
 .idea/*
 
 !.idea/codeStyles
 !.idea/runConfigurations
+!.idea/externalDependencies.xml


### PR DESCRIPTION
## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

As stated in https://www.jetbrains.com/help/idea/managing-plugins.html#required-plugins:

> A project may require plugins that provide support for certain technologies or frameworks.
> (...)
> The list of required plugins is stored in the `.idea/externalDependencies.xml` file of your project

In order to take advantage of this feature, the `.idea/externalDependencies.xml` file has to be shared with all contributors so that they're notified when they're missing a required plugin.