### PR TITLE
Add .pdm-python file to Python.patch

### DIFF
--- a/templates/Python.patch
+++ b/templates/Python.patch
@@ -6,3 +6,8 @@ poetry.toml
 
 # LSP config files
 pyrightconfig.json
+
+#   .pdm-python contains information about the local Python interpreter and shouldn't be included
+#   in version control.
+#   https://pdm-project.org/latest/usage/project/#working-with-version-control
+.pdm-python


### PR DESCRIPTION
Per the PDM documentation, the .pdm-python file should not be committed.

https://pdm-project.org/latest/usage/project/#working-with-version-control

# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Per https://github.com/toptal/gitignore/blob/7e72ecd8af69b39c25aedc645117f0dc261cedfd/.github/CONTRIBUTING.md I am updating the Python.patch file rather than the Python.gitignore file, as the latter exists in the base github/gitignore repository.

Here's the relevant information from [the PDM documentation](https://pdm-project.org/latest/usage/project/#working-with-version-control) about this specific change:

> You **must** commit the `pyproject.toml` file. You **should** commit the `pdm.lock` and `pdm.toml` file. **Do not** commit the `.pdm-python` file.

and

> `.pdm-python` stores the **Python path** used by the **current** project and doesn't need to be shared.