### PR TITLE
Create eide.gitignore

### DIFF
--- a/templates/eide.gitignore
+++ b/templates/eide.gitignore
@@ -1,0 +1,13 @@
+# dot files
+/.eide/log
+/.eide.usr.ctx.json
+
+# project out
+/build
+/bin
+/obj
+/out
+
+# eide template
+*.ept
+*.eide-template


### PR DESCRIPTION
### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

## Details

Add .ignore template for [eide (AKA "Embed IDE")](https://github.com/github0null/eide)

I referred to [eide document](https://github.com/github0null/eide-docs/blob/master/docs/getting-started/project_struct.md#git-ignore) and removed 2 items of VS Code though eide is a VS Code plugin.

I'm not sure if it is satisfied of some rules in this repo. If anything is not correct, I'll try to fix it.