### PR TITLE
ssh: ignore known_hosts.old

### DIFF
--- a/templates/SSH.gitignore
+++ b/templates/SSH.gitignore
@@ -1,3 +1,4 @@
 **/.ssh/id_*
 **/.ssh/*_id_*
 **/.ssh/known_hosts
+**/.ssh/known_hosts.old


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

It is created by OpenSSH from known_hosts from time to time.

Docs: https://serverfault.com/questions/1143760/how-to-prevent-openssh-from-creating-a-new-known-hosts-file-every-time-it-update