### PR TITLE
Don't ignore packagefiles in meson subprojects

### DIFF
--- a/templates/Meson.gitignore
+++ b/templates/Meson.gitignore
@@ -1,6 +1,8 @@
 # subproject directories
 /subprojects/*
 !/subprojects/*.wrap
+!subprojects/packagefiles
+
 
 # Meson Directories
 meson-logs


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ X] Template - Update existing `.gitignore` template

## Details

Don't ignore files in the subprojects/packagefiles folder for meson subprojects.
This folder is used for overlay directories.
See https://mesonbuild.com/Wrap-dependency-system-manual.html#accepted-configuration-properties-for-wraps