### PR TITLE
Add pixi environment directory to python gitignore

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -128,6 +128,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# pixi
+.pixi/
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The package manager pixi (https://github.com/prefix-dev/pixi) is being used (not only) for python projects and stores its environment in `.pixi`.