### PR TITLE
Add total pixi's configuration supports for Python.gitignore

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -109,6 +109,13 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 

--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -109,13 +109,6 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-#pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 

--- a/templates/Python.patch
+++ b/templates/Python.patch
@@ -6,3 +6,11 @@ poetry.toml
 
 # LSP config files
 pyrightconfig.json
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

**Reasons for making this change:**

[pixi](https://github.com/prefix-dev/pixi) is a package manager. (Almost used for Python developing)
I want to append pixi support for this project.
This appendix format is same as previous ones, pyenv, pipenv, pdm, poetry.
#576 is a proposal to append `pixi` support too. But that is not enough supports of pixi.

This pull requests include two type of changes for pixi's support.

First one is for `pixi.lock`. It just follows precedent cases(pipenv, poetry, pdm).
I don't think there is any problem to append this line.

Second one is for `.pixi`.
`pixi` create `.pixi` directory, just like Python's venv module creates one in the `.venv` directory. `.pixi` is a directory for setting up virtualenv.
It is recommended not to include this directory in version control in pixi system.

### Why `.pixi` is needed in gitignore.

When initialize pixi project (by running `pixi init` command), pixi automatically add the line of `.pixi` to `.gitignore` file. ([If already exist `.pixi` in user's .gitignore file, pixi doesn't change anything.](https://github.com/prefix-dev/pixi/blob/4653639f930621f55f8e2a5c3455f563bc900501/src/cli/init.rs#L468-L471))
But user may use this project's template after initialized pixi.
This change doesn't cause any breaking change. Appending `.pixi` in this project's template is reasonable.

- **Links to documentation supporting these rule changes:**
  https://prefix.dev/docs/pixi/cli#init

- **Link to application or project’s homepage**: https://pixi.sh/latest/