### PR TITLE
Add reference to `uv.lock` file in Python template

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -101,6 +101,13 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
+# uv
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://github.com/astral-sh/uv/blob/af9c2e6/crates/uv/src/commands/project/lock.rs#L240-L243
+#uv.lock
+
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

`uv` is a new Rust-based package manager for Python, and has its own lock file called `uv.lock`. This acts similarly to `poetry.lock` and the like.