### PR TITLE
Remove conan.lock from Conan ignores

### DIFF
--- a/templates/Conan.gitignore
+++ b/templates/Conan.gitignore
@@ -1,5 +1,4 @@
 # Conan build information
-conan.lock
 conanbuildinfo.*
 conaninfo.txt
 graph_info.json


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [*] Template - Update existing `.gitignore` template

## Details

`conan.lock` should usually be committed since Conan version 2.x (see https://github.com/conan-io/conan/issues/14150#issuecomment-1602705673).