### PR TITLE
Ignore Windows Zone.Identifier Alternate Data Stream(ADS) files

### DIFF
--- a/templates/Windows.gitignore
+++ b/templates/Windows.gitignore
@@ -22,3 +22,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Windows Alternate Data Stream(ADS) files
+*Zone.Identifier*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Windows could generate Alternate Data Stream(ADS) files with the name of `sample.txt: Zone.Identifier:$DATA`, see [microsoft docs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/6e3f7352-d11c-4d76-8c39-2516a9df36e8). 
When this file is committed to the Git repo, the repo will no longer be able to checkout, at least on the Windows system.

 