### PR TITLE
Update zig.gitignore to include .zig-cache dir

### DIFF
--- a/templates/zig.gitignore
+++ b/templates/zig.gitignore
@@ -1,6 +1,7 @@
 # Zig programming language
 
 zig-cache/
+.zig-cache/
 zig-out/
 build/
 build-*/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Zig 0.13.0 compiler uses `.zig-cache/` (with dot) instead of `zig-cache`, see https://ziglang.org/download/0.13.0/release-notes.html#codezig-cachecode-renamed-to-codezig-cachecode
We should leave the old `zig-cache` in the template for people using older versions of the zig compiler.