### PR TITLE
Added lock file (.lck) to KiCad.gitignore

### DIFF
--- a/templates/KiCad.gitignore
+++ b/templates/KiCad.gitignore
@@ -16,6 +16,7 @@ _autosave-*
 *-save.pro
 *-save.kicad_pcb
 fp-info-cache
+*.lck
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Since KiCad 8, there's a lock file created at the opening of the project and deleted when closed. This file can be ignored. Keeping this file can be a security issue since it writes the computer name and username into the file.