### PR TITLE
Remove IDE-specifics on Deno.gitignore

### DIFF
--- a/templates/Deno.gitignore
+++ b/templates/Deno.gitignore
@@ -1,6 +1,3 @@
-/.idea/
-/.vscode/
-
 /node_modules
 
 .env


### PR DESCRIPTION
# Pull Request

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Deno is IDE-agnostic and it relies some workspace settings that be fine-grained on IDE basis. I believe IDE-specifics should not be part of the Deno gitignore spec for that reason.

Details can be taken from my comment here: https://github.com/toptal/gitignore/pull/492#issuecomment-2360305232