### PR TITLE
fix: remove out of scope items in deno

### DIFF
--- a/templates/Deno.gitignore
+++ b/templates/Deno.gitignore
@@ -1,6 +1,3 @@
-/.idea/
-/.vscode/
-
 /node_modules
 
 .env


### PR DESCRIPTION
already covered by `vscode` and `idea`, not in the scope of deno
Also not what vscode implements, so conflicts
this PR fixes that