### PR TITLE
Add draw.io gitignore template

### DIFF
--- a/templates/DrawIO.gitignore
+++ b/templates/DrawIO.gitignore
@@ -1,0 +1,3 @@
+# draw.io backup/cache
+*.drawio.bkp
+*.drawio.dtmp


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [x] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details
draw.io is a diagramming tool that generates cache/backup files for recovery, which can be excluded from version control using a .gitignore entry like `*.drawio.dtmp` and `*.drawio.bkp`

***.drawio.dtmp**
![image](https://github.com/user-attachments/assets/c1f127c9-14d0-4b0b-bca5-5f4153397ad1)


***.drawio.bkp**
![image](https://github.com/user-attachments/assets/e114225b-bc63-4953-b427-f94e40ae83cd)


*replace this section with links and/or info about the proposed request*