### PR TITLE
Updated NCrunch cache path for v4.16+

### DIFF
--- a/templates/NCrunch.gitignore
+++ b/templates/NCrunch.gitignore
@@ -1,5 +1,6 @@
 # NCrunch
 *.ncrunch*.user
 _NCrunch_*
+.NCrunch_*
 *.crunch.xml
 nCrunchTemp_*


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @toptal/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

NCrunch updated the default location of the cache storage directory in version 4.16
https://github.com/toptal/gitignore.io/issues/648

> "Adjusted the default path for NCrunch's cache storage directory so that this now starts with a period instead of an underscore. For example, '_NCrunch_Solution' will now be '.NCrunch_Solution'. Solutions using the old path will continue to use the old path unless this is manually renamed. This change has been made to prevent VS from automatically including the files from NCrunch's cache storage directory in projects that may be stored adjacent to the solution file."
> https://www.ncrunch.net/download/showChangeLog?version=4.16

There is also an open Pull request for the same change https://github.com/github/gitignore/pull/4490 but it is almost 6 months old and not merged or commented on.